### PR TITLE
Branch auf den aktuellen Stand bringen

### DIFF
--- a/01-Demokratie-Freiheit/01-Demokratie-Freiheit.adoc
+++ b/01-Demokratie-Freiheit/01-Demokratie-Freiheit.adoc
@@ -9,3 +9,5 @@ include::1.3-Transparenz.adoc[]
 include::1.4-Privatsphäre.adoc[]
 
 include::1.5-Verbraucherschutz.adoc[]
+
+include::1.6-Rundfunk.adoc[]

--- a/01-Demokratie-Freiheit/1.6-Rundfunk.adoc
+++ b/01-Demokratie-Freiheit/1.6-Rundfunk.adoc
@@ -1,0 +1,7 @@
+## Öffentlich-rechtlicher Rundfunk
+
+Wir Liberale Demokraten fordern einen modernen und effizienten öffentlich-rechtlichen Rundfunk. In Zeiten der Digitalisierung sind Doppelstrukturen, wie sie sich durch die hohe Anzahl der Sender im Hörfunk und im Fernsehen mit einer großen Anzahl an Eigenproduktionen zwangsläufig ergeben, ein nicht mehr zu rechtfertigender Kostenaufwand. Die monatlichen Kosten für die Beitragszahler sollen gesenkt werden.
+
+Wir wollen, dass die regionenspezifischen Angebote des öffentlich-rechtlichen Rundfunks erhalten bleiben, die unnötige doppelte Produktion von Formaten mit ähnlichem oder gleichen Inhalt allerdings zusammengelegt wird. Die Anzahl der überregionalen Sender soll reduziert werden.
+
+Insgesamt soll der Fokus bei der Programmgestaltung auf Informationen, Kultur und Bildung liegen. Angebote für die junge Generation sollen verstärkt finanziert werden. Zudem soll es dem öffentlich-rechtlichen Rundfunk ermöglicht werden, eigen- oder auftragsproduzierte Inhalte länger in den jeweiligen Onlinemediatheken zur Verfügung zu stellen.

--- a/Programm.adoc
+++ b/Programm.adoc
@@ -1,9 +1,9 @@
-= Grundsatzprogramm
+= Programm
 der Liberalen Demokraten - Die Sozialliberalen
 Stand November 2020
 :doctype: book
 :icons: font
-:keywords: Grundsatzprogramm, Liberale Demokraten
+:keywords: Parteiprogramm, Liberale Demokraten
 :page-keywords: {keywords}
 :toc: macro
 :toclevels: 2

--- a/README.md
+++ b/README.md
@@ -1,13 +1,13 @@
-# Grundsatzprogramm
-Das Grundsatzprogramm der Liberalen Demokraten - Die Sozialliberalen.
+# Parteiprogramm
+Das Parteiprogramm der Liberalen Demokraten - Die Sozialliberalen.
 
-In dieser Repository wird das Grundsatzprogramm der Liberalen Demokraten - Die Sozialliberalen (LD) veröffentlicht und auch in Branches bearbeitet.
+In dieser Repository wird das Parteiprogramm der Liberalen Demokraten - Die Sozialliberalen (LD) veröffentlicht und auch in Branches bearbeitet.
 Die jeweils aktuelle Fassung ist in der [main](https://github.com/liberaledemokraten/grundsatzprogramm/tree/main) branch
-unter [Grundsatzprogramm.adoc](Grundsatzprogramm.adoc) zu finden.
+unter [Programm.adoc](Programm.adoc) zu finden.
 Das Repository bzw. Forks dessen verwenden wir hierbei ggf. auch zur Weiterentwicklung der Programmpunkte zur Vorlage beim nächsten Parteitag.
 Die Formatierung ist hierbei nicht auf GitHub optimiert, sondern zur Nutzung mit [Asciidoctor PDF](https://github.com/asciidoctor/asciidoctor-pdf). 
 
-Eines der Ziele der Veröffentlichung auf GitHub zusätzlich zu der [Veröffentlichung auf unserer Webseite](https://liberale-demokraten.de/positionen/) ist es, unseren Forderung der freien und liberalen Kultur der Transparenz
+Eines der Ziele der Veröffentlichung auf GitHub zusätzlich zu der [Veröffentlichung auf unserer Webseite](https://liberale-demokraten.de/alle-positionen/) ist es, unseren Forderung der freien und liberalen Kultur der Transparenz
 und Offenheit gerecht zu werden. Auch wenn wir das parteiintern schon immer derart handhaben, haben diese Prinzipien auch nach außen hin zu gelten.
 Hinzu ermöglicht uns `git` die Versionsgeschichte und Entwicklung unseres Programmes besser nachvollziehen zu können.
 


### PR DESCRIPTION
Im Branch '49BPT_2dBPT' sind die Änderungen durch die Umbenennung von 'Grundsatzprogramm' in 'Parteiprogramm' aufgrund eines Fehlers noch nicht miteingeflossen. Der Merge ist ein Fix hierzu.